### PR TITLE
Update ScheduleProvider to handle new PVA website interface

### DIFF
--- a/lib/pva/cli.rb
+++ b/lib/pva/cli.rb
@@ -60,7 +60,7 @@ the list.
           else
             puts "Schedule for #{team.name}"
             schedule_provider = ScheduleProvider.new
-            matches = schedule_provider.get_schedule(team.id)
+            matches = schedule_provider.get_schedule(team)
             matches.each { |m| puts m }
           end
         end

--- a/lib/pva/schedule_provider.rb
+++ b/lib/pva/schedule_provider.rb
@@ -3,17 +3,18 @@ module Pva
 
     SCHEDULES_URL = 'http://portlandvolleyball.org/schedules.php'
 
-    def get_schedule(team_id)
-      matches_data(team_id).map { |m| match_from_array(m) }
+    def get_schedule(team)
+      matches_data(team).map { |m| match_from_array(m) }
     end
 
     private
 
-    def matches_data(team_id)
-      response = HTTParty.post(SCHEDULES_URL, body: { teams: team_id })
+    def matches_data(team)
+      response = HTTParty.get(SCHEDULES_URL)
       doc = Nokogiri::HTML(response)
 
-      doc.css('tr')[1..-1]
+      doc.css("table.schedule-table")
+        .xpath("//tr[(td//text()[contains(., '#{team.name}')]) and (td[6]//text()[contains(., '#{team.division}')])]")
         .map { |tr| tr.element_children.map(&:content).map(&:strip) }
     end
 

--- a/lib/pva/version.rb
+++ b/lib/pva/version.rb
@@ -1,3 +1,3 @@
 module Pva
-  VERSION = "0.2.1"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
Fixes #4 by updating the ScheduleProvider to reflect the fact that the filtering is no longer done on the server side on the PVA website via a post with the team_id, but rather on the client side with javascript. The ScheduleProvider now accepts an entire team object instead of the team id, and gets all the schedules from the website, then filters them by team name and division.